### PR TITLE
Task 2: Implement lookup() with comprehensive testing

### DIFF
--- a/task2/logic.py
+++ b/task2/logic.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def lookup() -> Any:
+    pass

--- a/task2/logic.py
+++ b/task2/logic.py
@@ -2,6 +2,10 @@ from typing import Any, Dict
 
 
 def lookup(obj: Dict, path: str) -> Any:
+
+    if not isinstance(path, str):
+        return None
+
     try:
         for key in path.split("."):
             if not isinstance(obj, Dict):

--- a/task2/logic.py
+++ b/task2/logic.py
@@ -1,5 +1,19 @@
-from typing import Any
+from typing import Any, Dict
 
 
-def lookup() -> Any:
-    pass
+def lookup(obj: Dict, path: str) -> Any:
+    try:
+        for key in path.split("."):
+            if not isinstance(obj, Dict):
+                return None
+
+            if key in obj:
+                obj = obj[key]
+            else:
+                try:
+                    obj = obj[int(key)]
+                except(ValueError, KeyError):
+                    return None
+        return obj
+    except(KeyError, TypeError):
+        return None

--- a/task2/logic.py
+++ b/task2/logic.py
@@ -2,22 +2,39 @@ from typing import Any, Dict
 
 
 def lookup(obj: Dict, path: str) -> Any:
+    """
+    Safely looks up a value in a nested dictionary using a dot-separated string path.
 
+    Each segment in the path is used to traverse one level deeper in the nested structure.
+    Supports both string and integer keys (when strings can be cast to integers).
+    Returns None if the path is invalid or intermediate levels are not dictionaries.
+
+    Args:
+        obj: The dictionary to traverse.
+        path: Dot-separated string representing the lookup path.
+
+    Returns:
+        The value at the end of the path if valid, otherwise None.
+    """
     if not isinstance(path, str):
-        return None
+        return None  # Reject non-string path input early
 
     try:
         for key in path.split("."):
+            # If current obj is not a dictionary, stop traversal
             if not isinstance(obj, Dict):
                 return None
 
+            # Try to access using string key first
             if key in obj:
                 obj = obj[key]
             else:
+                # If that fails, try using integer conversion
                 try:
                     obj = obj[int(key)]
-                except(ValueError, KeyError):
+                except (ValueError, KeyError):
                     return None
+
         return obj
-    except(KeyError, TypeError):
+    except (KeyError, TypeError):
         return None

--- a/tests/test_task2.py
+++ b/tests/test_task2.py
@@ -65,6 +65,26 @@ class TestLookupFunction(unittest.TestCase):
         obj = {"a b": {"c d": "value"}}
         self.assertEqual(lookup(obj, "a b.c d"), "value")
 
+    def test_path_is_not_string(self):
+        self.assertIsNone(lookup({"a": {"b": 1}}, None))
+        self.assertIsNone(lookup({"a": {"b": 1}}, 123))
+
+    def test_integer_dict_keys(self):
+        self.assertEqual(lookup({1: {2: "ok"}}, "1.2"), "ok")
+
+    def test_empty_string_key(self):
+        self.assertEqual(lookup({"": {"": "empty"}}, "."), "empty")
+
+    def test_valid_prefix_then_invalid(self):
+        self.assertIsNone(lookup({"a": {"b": 1}}, "a.b.c"))
+
+    def test_path_with_trailing_dot(self):
+        self.assertIsNone(lookup({"a": {"b": 1}}, "a.b."))
+
+    def test_path_with_leading_trailing_spaces(self):
+        obj = {" a ": {" b ": "value"}}
+        self.assertEqual(lookup(obj, " a . b "), "value")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_task2.py
+++ b/tests/test_task2.py
@@ -1,23 +1,17 @@
 import unittest
-from task2.logic import lookup  # ← import, don’t redefine
+
+from task2.logic import lookup  # Import lookup from logic module
 
 
 class TestLookupFunction(unittest.TestCase):
+
+    # === Basic Valid Lookups ===
 
     def test_valid_single_level_lookup(self):
         self.assertEqual(lookup({"key": "value"}, "key"), "value")
 
     def test_valid_nested_lookup(self):
         self.assertEqual(lookup({"a": {"b": {"c": "value"}}}, "a.b.c"), "value")
-
-    def test_invalid_top_level_key(self):
-        self.assertIsNone(lookup({"a": "b"}, "x"))
-
-    def test_invalid_nested_key(self):
-        self.assertIsNone(lookup({"a": {"b": "c"}}, "a.x"))
-
-    def test_partial_path_break(self):
-        self.assertIsNone(lookup({"a": {"b": 5}}, "a.b.c"))
 
     def test_integer_keys_as_strings(self):
         self.assertEqual(lookup({"a": {"1": {"2": "x"}}}, "a.1.2"), "x")
@@ -28,20 +22,33 @@ class TestLookupFunction(unittest.TestCase):
     def test_list_in_value(self):
         self.assertEqual(lookup({"a": {"b": [1, 2]}}, "a.b"), [1, 2])
 
-    def test_path_empty_string(self):
-        self.assertIsNone(lookup({"a": 1}, ""))
-
-    def test_value_is_none(self):
-        self.assertIsNone(lookup({"a": {"b": None}}, "a.b"))
-
-    def test_middle_non_dict_type(self):
-        self.assertIsNone(lookup({"a": "b"}, "a.b"))
-
     def test_value_is_dict(self):
         self.assertEqual(lookup({"a": {"b": {"c": 5}}}, "a.b"), {"c": 5})
 
-    def test_lookup_numeric_string_as_key_in_list(self):
-        self.assertIsNone(lookup({"a": {"b": [1, 2]}}, "a.b.0"))
+    def test_lookup_with_spaces(self):
+        obj = {"a b": {"c d": "value"}}
+        self.assertEqual(lookup(obj, "a b.c d"), "value")
+
+    def test_valid_nested_boolean_lookup(self):
+        self.assertTrue(lookup({"a": {"b": {"c": True}}}, "a.b.c"))
+
+    def test_integer_dict_keys(self):
+        self.assertEqual(lookup({1: {2: "ok"}}, "1.2"), "ok")
+
+    def test_empty_string_key(self):
+        self.assertEqual(lookup({"": {"": "empty"}}, "."), "empty")
+
+    def test_path_with_leading_trailing_spaces(self):
+        obj = {" a ": {" b ": "value"}}
+        self.assertEqual(lookup(obj, " a . b "), "value")
+
+    def test_deep_integer_keys_as_mixed_types(self):
+        self.assertEqual(lookup({0: {"1": {2: "deep"}}}, "0.1.2"), "deep")
+
+    def test_key_with_dot_in_name(self):
+        self.assertEqual(lookup({"a.b": {"c": "value"}}, "a.b.c"), None)  # Because "a.b" is not a real path
+
+    # === Realistic JSON Structures ===
 
     def test_realistic_json_data(self):
         obj = {
@@ -55,25 +62,41 @@ class TestLookupFunction(unittest.TestCase):
         self.assertTrue(lookup(obj, "user.active"))
         self.assertIsNone(lookup(obj, "user.status"))
 
+    # === Invalid Lookups and Edge Cases ===
+
+    def test_invalid_top_level_key(self):
+        self.assertIsNone(lookup({"a": "b"}, "x"))
+
+    def test_invalid_nested_key(self):
+        self.assertIsNone(lookup({"a": {"b": "c"}}, "a.x"))
+
+    def test_partial_path_break(self):
+        self.assertIsNone(lookup({"a": {"b": 5}}, "a.b.c"))
+
+    def test_path_empty_string(self):
+        self.assertIsNone(lookup({"a": 1}, ""))
+
+    def test_value_is_none(self):
+        self.assertIsNone(lookup({"a": {"b": None}}, "a.b"))
+
+    def test_middle_non_dict_type(self):
+        self.assertIsNone(lookup({"a": "b"}, "a.b"))
+
+    def test_lookup_numeric_string_as_key_in_list(self):
+        self.assertIsNone(lookup({"a": {"b": [1, 2]}}, "a.b.0"))
+
     def test_invalid_path_type_safety(self):
         self.assertIsNone(lookup(None, "a.b"))
+
+    def test_list_mid_path_should_fail(self):
+        self.assertIsNone(lookup({"a": {"b": [1, 2, 3]}}, "a.b.c"))
 
     def test_object_is_empty(self):
         self.assertIsNone(lookup({}, "a"))
 
-    def test_lookup_with_spaces(self):
-        obj = {"a b": {"c d": "value"}}
-        self.assertEqual(lookup(obj, "a b.c d"), "value")
-
     def test_path_is_not_string(self):
         self.assertIsNone(lookup({"a": {"b": 1}}, None))
         self.assertIsNone(lookup({"a": {"b": 1}}, 123))
-
-    def test_integer_dict_keys(self):
-        self.assertEqual(lookup({1: {2: "ok"}}, "1.2"), "ok")
-
-    def test_empty_string_key(self):
-        self.assertEqual(lookup({"": {"": "empty"}}, "."), "empty")
 
     def test_valid_prefix_then_invalid(self):
         self.assertIsNone(lookup({"a": {"b": 1}}, "a.b.c"))
@@ -81,9 +104,8 @@ class TestLookupFunction(unittest.TestCase):
     def test_path_with_trailing_dot(self):
         self.assertIsNone(lookup({"a": {"b": 1}}, "a.b."))
 
-    def test_path_with_leading_trailing_spaces(self):
-        obj = {" a ": {" b ": "value"}}
-        self.assertEqual(lookup(obj, " a . b "), "value")
+    def test_single_dot_path(self):
+        self.assertIsNone(lookup({"a": 1}, "."))
 
 
 if __name__ == "__main__":

--- a/tests/test_task2.py
+++ b/tests/test_task2.py
@@ -1,0 +1,70 @@
+import unittest
+from task2.logic import lookup  # ← import, don’t redefine
+
+
+class TestLookupFunction(unittest.TestCase):
+
+    def test_valid_single_level_lookup(self):
+        self.assertEqual(lookup({"key": "value"}, "key"), "value")
+
+    def test_valid_nested_lookup(self):
+        self.assertEqual(lookup({"a": {"b": {"c": "value"}}}, "a.b.c"), "value")
+
+    def test_invalid_top_level_key(self):
+        self.assertIsNone(lookup({"a": "b"}, "x"))
+
+    def test_invalid_nested_key(self):
+        self.assertIsNone(lookup({"a": {"b": "c"}}, "a.x"))
+
+    def test_partial_path_break(self):
+        self.assertIsNone(lookup({"a": {"b": 5}}, "a.b.c"))
+
+    def test_integer_keys_as_strings(self):
+        self.assertEqual(lookup({"a": {"1": {"2": "x"}}}, "a.1.2"), "x")
+
+    def test_integer_keys(self):
+        self.assertEqual(lookup({"a": {1: {2: "value"}}}, "a.1.2"), "value")
+
+    def test_list_in_value(self):
+        self.assertEqual(lookup({"a": {"b": [1, 2]}}, "a.b"), [1, 2])
+
+    def test_path_empty_string(self):
+        self.assertIsNone(lookup({"a": 1}, ""))
+
+    def test_value_is_none(self):
+        self.assertIsNone(lookup({"a": {"b": None}}, "a.b"))
+
+    def test_middle_non_dict_type(self):
+        self.assertIsNone(lookup({"a": "b"}, "a.b"))
+
+    def test_value_is_dict(self):
+        self.assertEqual(lookup({"a": {"b": {"c": 5}}}, "a.b"), {"c": 5})
+
+    def test_lookup_numeric_string_as_key_in_list(self):
+        self.assertIsNone(lookup({"a": {"b": [1, 2]}}, "a.b.0"))
+
+    def test_realistic_json_data(self):
+        obj = {
+            "user": {
+                "details": {"name": "Jane", "age": 30},
+                "active": True
+            }
+        }
+        self.assertEqual(lookup(obj, "user.details.name"), "Jane")
+        self.assertEqual(lookup(obj, "user.details.age"), 30)
+        self.assertTrue(lookup(obj, "user.active"))
+        self.assertIsNone(lookup(obj, "user.status"))
+
+    def test_invalid_path_type_safety(self):
+        self.assertIsNone(lookup(None, "a.b"))
+
+    def test_object_is_empty(self):
+        self.assertIsNone(lookup({}, "a"))
+
+    def test_lookup_with_spaces(self):
+        obj = {"a b": {"c d": "value"}}
+        self.assertEqual(lookup(obj, "a b.c d"), "value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR completes Task 2 by:

- Implementing `lookup(obj, path)` to safely traverse nested dicts with dot-separated keys  
- Handling string and integer keys, invalid paths, non-dict segments, and None inputs  
- Adding a full suite of unit tests covering valid lookups, edge cases, and error scenarios  
- Ensuring PEP 8 style, clear docstring, and O(k) time complexity (k = number of path segments)

Once merged, `main` will include the fully tested, PEP 8-compliant, and performant implementation of Task 2.